### PR TITLE
Send Content-Type with request

### DIFF
--- a/mopidy_webhooks/utils.py
+++ b/mopidy_webhooks/utils.py
@@ -22,7 +22,10 @@ def send_webhook(config, payload):
         response = requests.post(
             config['webhook_url'],
             data=json.dumps(payload, cls=ModelJSONEncoder),
-            headers={config['api_key_header_name']: config['api_key']},
+            headers={
+                config['api_key_header_name']: config['api_key'],
+                'Content-Type': 'application/json',
+            },
         )
     except Exception as e:
         logger.warning('Unable to send webhook: ({1}) {2}'.format(


### PR DESCRIPTION
HTTP requests that send JSON should have the content type appropriately set, and that _would_ be the case here, if `requests.post(..., json=...)` could be used. But since that's not possible here, we have to do it manually, by setting the `Content-Type` to `application/json`.

Before this commit, my Flask(y) server wouldn't understand that this is JSON, now it does.

Possibly related to #1.